### PR TITLE
Only consider PMF events from repositories that are closely related to the PL stack

### DIFF
--- a/app/models/pmf.rb
+++ b/app/models/pmf.rb
@@ -267,6 +267,15 @@ class Pmf
   end
 
   def self.event_scope
-    Event.not_core.where.not(event_type: 'WatchEvent')
+    # not star events
+    # not PL employees/contractors
+    # only repos with pl dependencies or search results or pl owned repos
+
+    repository_ids = Repository.with_internal_deps.pluck(:id)
+    repository_ids += Repository.with_search_results.pluck(:id)
+    repository_ids += Repository.internal.pluck(:id)
+    repository_ids.uniq!
+
+    Event.not_core.where.not(event_type: 'WatchEvent').where(repository_id: repository_ids)
   end
 end

--- a/app/models/pmf_repo.rb
+++ b/app/models/pmf_repo.rb
@@ -267,6 +267,15 @@ class PmfRepo
   end
 
   def self.event_scope
-    Event.not_core.where.not(event_type: 'WatchEvent')
+    # not star events
+    # not PL employees/contractors
+    # only repos with pl dependencies or search results or pl owned repos
+
+    repository_ids = Repository.with_internal_deps.pluck(:id)
+    repository_ids += Repository.with_search_results.pluck(:id)
+    repository_ids += Repository.internal.pluck(:id)
+    repository_ids.uniq!
+
+    Event.not_core.where.not(event_type: 'WatchEvent').where(repository_id: repository_ids)
   end
 end

--- a/app/models/pmf_repo.rb
+++ b/app/models/pmf_repo.rb
@@ -273,7 +273,7 @@ class PmfRepo
 
     repository_ids = Repository.with_internal_deps.pluck(:id)
     repository_ids += Repository.with_search_results.pluck(:id)
-    repository_ids += Repository.internal.pluck(:id)
+    repository_ids -= Repository.internal.pluck(:id)
     repository_ids.uniq!
 
     Event.not_core.where.not(event_type: 'WatchEvent').where(repository_id: repository_ids)


### PR DESCRIPTION
The initial attempt at PMF scoring used all GitHub events (excluding stars) from all internal and collaborator repositories indexed in the ecosystem dashboard. 

But many of the collaborator repos get little or no value from the PL stack and are only included because they belong to a collaborator org that has one or more open source repos that integrate IPFS/Libp2p or Filecoin. 

I'm proposing that we only consider events triggered on repositories that meet at least one of three conditions:

- the repository has a dependency (direct or transitive) on an PL repo
- the repository matches a keyword search of "IPFS" or "Filecoin" across it's metadata, code, commits, issues and pull requests
- the repository belongs to a PL org (ipfs, ipld, libp2p etc)

This means that when scoring users, our score is more tightly focused on their contributions to repositories that actually use the PL stack. It would filter out a large chunk of collab repos that don't directly use the PL stack.

For example, Netflix has 172 open source repositories and only one of them uses IPFS, this PR would ignore contributions to all their other non-PL-related repositories. 

Similarly IBM has 1,600 repositories and only 6 of them use parts of the PL stack, this PR would ignore contributions from 1594 of their repositories.

Overall it reduces the total number of unique users fed into the PMF state machine by over 50% but will increase the confidence in the numbers significantly.

_note: numbers below are only from the IPFS instance of the ecosystem dashboard_

## PMF inputs before making this change:

1,339,632 total events
46,289 unique actor names
9,907 unique repos

## PMF inputs after 

801,071 total events
21,091 unique actor names
3,920 unique repos 

excluded repos: https://gist.github.com/andrew/ee42c762c469c439dc8032926719e0eb
included repos: https://gist.github.com/andrew/9fb08c5e16a73e8fb5f4976b988f22a8

note: more community repos will be included over the next week or so as their events are downloaded from GitHub, if a repo is not included in the "excluded repos" list it's events will still be considered once imported.