### PR TITLE
Refactor PMF calculations to enable granular caching

### DIFF
--- a/app/controllers/pmf_controller.rb
+++ b/app/controllers/pmf_controller.rb
@@ -2,9 +2,7 @@ class PmfController < ApplicationController
   def states
     parse_date_params
 
-    json = Rails.cache.fetch(['states', @start_date, @end_date, @window], expires_in: 12.hours) do
-      Pmf.states_summary(@start_date, @end_date, @window).to_json
-    end
+    json = Pmf.states_summary(@start_date, @end_date, @window).to_json
 
     render json: json
   end
@@ -13,9 +11,7 @@ class PmfController < ApplicationController
     state_name = params[:state_name]
     parse_date_params
 
-    json = Rails.cache.fetch(['state', state_name, @start_date, @end_date, @window], expires_in: 12.hours) do
-      Pmf.state(state_name, @start_date, @end_date, @window).to_json
-    end
+    json = Pmf.state(state_name, @start_date, @end_date, @window).to_json
 
     render json: json
   end
@@ -23,9 +19,7 @@ class PmfController < ApplicationController
   def transitions
     parse_date_params
 
-    json = Rails.cache.fetch(['transitions', @start_date, @end_date, @window], expires_in: 12.hours) do
-      Pmf.transitions(@start_date, @end_date, @window).to_json
-    end
+    json = Pmf.transitions(@start_date, @end_date, @window).to_json
 
     render json: json
   end
@@ -34,9 +28,7 @@ class PmfController < ApplicationController
     transition_name = params[:transition_name]
     parse_date_params
 
-    json = Rails.cache.fetch(['transition', transition_name, @start_date, @end_date, @window], expires_in: 12.hours) do
-      Pmf.transition(transition_name, @start_date, @end_date, @window).to_json
-    end
+    json = Pmf.transition(transition_name, @start_date, @end_date, @window).to_json
 
     render json: json
   end

--- a/app/controllers/pmf_repo_controller.rb
+++ b/app/controllers/pmf_repo_controller.rb
@@ -2,9 +2,7 @@ class PmfRepoController < ApplicationController
   def states
     parse_date_params
 
-    json = Rails.cache.fetch(['repo_states', @start_date, @end_date, @window], expires_in: 12.hours) do
-      PmfRepo.states_summary(@start_date, @end_date, @window).to_json
-    end
+    json = PmfRepo.states_summary(@start_date, @end_date, @window).to_json
 
     render json: json
   end
@@ -13,9 +11,7 @@ class PmfRepoController < ApplicationController
     state_name = params[:state_name]
     parse_date_params
 
-    json = Rails.cache.fetch(['repo_state', state_name, @start_date, @end_date, @window], expires_in: 12.hours) do
-      PmfRepo.state(state_name, @start_date, @end_date, @window).to_json
-    end
+    json = PmfRepo.state(state_name, @start_date, @end_date, @window).to_json
 
     render json: json
   end
@@ -23,9 +19,7 @@ class PmfRepoController < ApplicationController
   def transitions
     parse_date_params
 
-    json = Rails.cache.fetch(['repo_transitions', @start_date, @end_date, @window], expires_in: 12.hours) do
-      PmfRepo.transitions(@start_date, @end_date, @window).to_json
-    end
+    json = PmfRepo.transitions(@start_date, @end_date, @window).to_json
 
     render json: json
   end
@@ -34,9 +28,7 @@ class PmfRepoController < ApplicationController
     transition_name = params[:transition_name]
     parse_date_params
 
-    json = Rails.cache.fetch(['repo_transition', transition_name, @start_date, @end_date, @window], expires_in: 12.hours) do
-      PmfRepo.transition(transition_name, @start_date, @end_date, @window).to_json
-    end
+    json = PmfRepo.transition(transition_name, @start_date, @end_date, @window).to_json
 
     render json: json
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,9 +16,7 @@ class UsersController < ApplicationController
     @end_date = Time.now.beginning_of_week
     @window = 1
 
-    @data = Rails.cache.fetch(['state', state_name, @start_date, @end_date, @window], expires_in: 1.hours) do
-      Pmf.state(state_name, @start_date, @end_date, @window)
-    end
+    @data = Pmf.state(state_name, @start_date, @end_date, @window)
 
     if @data
       all_users = @data.first[:states].first[1]


### PR DESCRIPTION
Significantly rewrote the PMF class to make individual sql queries for each week and aggressively cache the result rather than one big sql query for the whole dataset. This means we should be able to:

- prewarm a lot of cache and then pluck those caches on demand via url parameters with zero sql queries
- cache each week as it's loaded, if we timeout, at least the second time will be able to use any caches generated in the first request
- end date is now a real parameter, which will make adding the month version easier

Also a lot less code and fixed a bug with first time user counts as well.

Opening as draft as I still need to copy the refactor over into the `PmfRepo` class